### PR TITLE
refactor: use signals for language and menu

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -31,7 +31,7 @@
       <app-theme-toggle></app-theme-toggle>
       
       <app-mobile-menu
-        [isOpen]="isMobileMenuOpen"
+        [isOpen]="isMobileMenuOpen()"
         [currentLanguage]="currentLanguage"
         [translations]="translations"
         (menuToggle)="toggleMobileMenu()"

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -434,6 +434,8 @@ body {
   
   .nav-menu {
     gap: var(--spacing-lg);
+    flex-wrap: wrap;
+    justify-content: center;
   }
 }
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Inject, PLATFORM_ID } from '@angular/core';
+import { Component, OnInit, Inject, PLATFORM_ID, signal, effect } from '@angular/core';
 import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { LanguageService, Language } from './services/language.service';
@@ -17,7 +17,7 @@ export class App implements OnInit {
   protected title = 'Philip Ramkeerat - Senior Angular Developer';
   protected currentLanguage: Language = 'en';
   protected translations: any;
-  protected isMobileMenuOpen = false;
+  protected isMobileMenuOpen = signal(false);
   protected currentYear: number = new Date().getFullYear();
 
   constructor(
@@ -25,9 +25,9 @@ export class App implements OnInit {
     private themeService: ThemeService,
     @Inject(PLATFORM_ID) private platformId: Object
   ) {
-    this.languageService.currentLanguage$.subscribe(lang => {
-      this.currentLanguage = lang;
-      this.translations = this.languageService.getTranslations();
+    effect(() => {
+      this.currentLanguage = this.languageService.language();
+      this.translations = this.languageService.translations();
     });
   }
 
@@ -48,7 +48,7 @@ export class App implements OnInit {
   }
 
   toggleMobileMenu(): void {
-    this.isMobileMenuOpen = !this.isMobileMenuOpen;
+    this.isMobileMenuOpen.update(open => !open);
   }
 
   onMobileLanguageChange(language: string): void {

--- a/src/app/components/about/about.component.ts
+++ b/src/app/components/about/about.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LanguageService } from '../../services/language.service';
 
@@ -9,14 +9,12 @@ import { LanguageService } from '../../services/language.service';
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.scss']
 })
-export class AboutComponent implements OnInit {
+export class AboutComponent {
   translations: any;
 
-  constructor(private languageService: LanguageService) {}
-
-  ngOnInit() {
-    this.languageService.currentLanguage$.subscribe(() => {
-      this.translations = this.languageService.getTranslations();
+  constructor(private languageService: LanguageService) {
+    effect(() => {
+      this.translations = this.languageService.translations();
     });
   }
-} 
+}

--- a/src/app/components/contact/contact.component.ts
+++ b/src/app/components/contact/contact.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { LanguageService, Language } from '../../services/language.service';
+import { LanguageService } from '../../services/language.service';
 
 @Component({
   selector: 'app-contact',
@@ -9,14 +9,12 @@ import { LanguageService, Language } from '../../services/language.service';
   templateUrl: './contact.component.html',
   styleUrls: ['./contact.component.scss']
 })
-export class ContactComponent implements OnInit {
+export class ContactComponent {
   translations: any;
 
-  constructor(private languageService: LanguageService) {}
-
-  ngOnInit(): void {
-    this.languageService.currentLanguage$.subscribe((lang: Language) => {
-      this.translations = this.languageService.getTranslations();
+  constructor(private languageService: LanguageService) {
+    effect(() => {
+      this.translations = this.languageService.translations();
     });
   }
-} 
+}

--- a/src/app/components/experience/experience.component.ts
+++ b/src/app/components/experience/experience.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { LanguageService, Language } from '../../services/language.service';
+import { LanguageService } from '../../services/language.service';
 
 @Component({
   selector: 'app-experience',
@@ -9,7 +9,7 @@ import { LanguageService, Language } from '../../services/language.service';
   templateUrl: './experience.component.html',
   styleUrls: ['./experience.component.scss']
 })
-export class ExperienceComponent implements OnInit {
+export class ExperienceComponent {
   translations: any;
   experiences: any[] = [];
 
@@ -103,12 +103,11 @@ export class ExperienceComponent implements OnInit {
     }
   ];
 
-  constructor(private languageService: LanguageService) {}
-
-  ngOnInit(): void {
-    this.languageService.currentLanguage$.subscribe((lang: Language) => {
-      this.translations = this.languageService.getTranslations();
+  constructor(private languageService: LanguageService) {
+    effect(() => {
+      const lang = this.languageService.language();
+      this.translations = this.languageService.translations();
       this.experiences = lang === 'pt' ? this.experiencesPt : this.experiencesEn;
     });
   }
-} 
+}

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { LanguageService } from '../../services/language.service';
@@ -10,15 +10,12 @@ import { LanguageService } from '../../services/language.service';
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss']
 })
-export class HomeComponent implements OnInit {
+export class HomeComponent {
   translations: any;
-  
-  constructor(private languageService: LanguageService) {}
-  
-  ngOnInit() {
-    this.translations = this.languageService.getTranslations();
-    this.languageService.currentLanguage$.subscribe(() => {
-      this.translations = this.languageService.getTranslations();
+
+  constructor(private languageService: LanguageService) {
+    effect(() => {
+      this.translations = this.languageService.translations();
     });
   }
-} 
+}

--- a/src/app/components/skills/skills.component.ts
+++ b/src/app/components/skills/skills.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { LanguageService, Language } from '../../services/language.service';
+import { LanguageService } from '../../services/language.service';
 
 @Component({
   selector: 'app-skills',
@@ -9,14 +9,12 @@ import { LanguageService, Language } from '../../services/language.service';
   templateUrl: './skills.component.html',
   styleUrls: ['./skills.component.scss']
 })
-export class SkillsComponent implements OnInit {
+export class SkillsComponent {
   translations: any;
 
-  constructor(private languageService: LanguageService) {}
-
-  ngOnInit(): void {
-    this.languageService.currentLanguage$.subscribe((lang: Language) => {
-      this.translations = this.languageService.getTranslations();
+  constructor(private languageService: LanguageService) {
+    effect(() => {
+      this.translations = this.languageService.translations();
     });
   }
-} 
+}


### PR DESCRIPTION
## Summary
- switch language service to signal-based state and computed translations
- update app and feature components to react via signals
- improve nav responsiveness with wrapping menu

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build` *(fails: inlining of fonts returned status code 403)*


------
https://chatgpt.com/codex/tasks/task_e_68962e7f88b08325ab0f0fb17a53bccc